### PR TITLE
Created 247ops group with admin privileges added new users to that group.

### DIFF
--- a/lab/global/iam/groups.tf
+++ b/lab/global/iam/groups.tf
@@ -3,6 +3,19 @@ resource "aws_iam_group" "developers" {
   path = "/"
 }
 
+
+resource "aws_iam_group_membership" "developers_members" {
+  name = "developers_members"
+
+  users = [
+    "${aws_iam_user.arun_kumar.name}",
+    "${aws_iam_user.rohit_gupta.name}",
+    "${aws_iam_user.mohan_kumar.name}",
+  ]
+
+  group = "${aws_iam_group.developers.name}"
+}
+
 resource "aws_iam_group_policy" "developers_policy" {
   name  = "developers_policy"
   group = "${aws_iam_group.developers.id}"
@@ -26,4 +39,26 @@ resource "aws_iam_group_policy" "developers_policy" {
    ]
   }
 EOF
+}
+
+resource "aws_iam_group" "247ops" {
+  name = "247ops"
+  path = "/"
+}
+
+resource "aws_iam_group_policy_attachment" "admin_policy_attach" {
+  group = "${aws_iam_group.247ops.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+resource "aws_iam_group_membership" "247ops_members" {
+  name = "247_membership"
+
+  users = [
+    "${aws_iam_user.arun_kumar.name}",
+    "${aws_iam_user.rohit_gupta.name}",
+    "${aws_iam_user.mohan_kumar.name}",
+  ]
+
+  group = "${aws_iam_group.247ops.name}"
 }


### PR DESCRIPTION
Terraform plan output:-

```Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  + module.iam_groups.aws_iam_group.247ops
      id:               <computed>
      arn:              <computed>
      name:             "247ops"
      path:             "/"
      unique_id:        <computed>

  + module.iam_groups.aws_iam_group_membership.247ops_members
      id:               <computed>
      group:            "247ops"
      name:             "247_membership"
      users.#:          "3"
      users.2992600046: "rohit.gupta"
      users.4246724926: "mohan.kumar"
      users.830743574:  "arun.kumar"

  + module.iam_groups.aws_iam_group_membership.developers_members
      id:               <computed>
      group:            "developers"
      name:             "developers_members"
      users.#:          "3"
      users.2992600046: "rohit.gupta"
      users.4246724926: "mohan.kumar"
      users.830743574:  "arun.kumar"

  + module.iam_groups.aws_iam_group_policy_attachment.admin_policy_attach
      id:               <computed>
      group:            "247ops"
      policy_arn:       "arn:aws:iam::aws:policy/AdministratorAccess"


Plan: 4 to add, 0 to change, 0 to destroy.

------------------------------------------------------------------------

Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if
"terraform apply" is subsequently run.
