### PR TITLE
add vpc for dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-*.provider.tf*
-*.backend.tf*
+provider.tf

--- a/lab/.terraform/modules/97a91f34d4cb48ffc32962c3dec7ed69
+++ b/lab/.terraform/modules/97a91f34d4cb48ffc32962c3dec7ed69
@@ -1,0 +1,1 @@
+/home/rohit.gupta/infra-terraform/lab/ap-south-1/dev

--- a/lab/.terraform/modules/modules.json
+++ b/lab/.terraform/modules/modules.json
@@ -1,1 +1,1 @@
-{"Modules":[{"Source":"./global/iam","Key":"1.iam_groups;./global/iam","Version":"","Dir":".terraform/modules/7086798b9c2ad816ba3ffcc42b8e381e","Root":""}]}
+{"Modules":[{"Source":"./global/iam","Key":"1.iam_groups;./global/iam","Version":"","Dir":".terraform/modules/7086798b9c2ad816ba3ffcc42b8e381e","Root":""},{"Source":"./ap-south-1/dev","Key":"1.vpc;./ap-south-1/dev","Version":"","Dir":".terraform/modules/97a91f34d4cb48ffc32962c3dec7ed69","Root":""}]}

--- a/lab/ap-south-1/dev/variables.tf
+++ b/lab/ap-south-1/dev/variables.tf
@@ -1,0 +1,15 @@
+variable "environment" {
+  default = "dev"
+}
+
+
+# VPC Variables
+variable "vpc_cidr" {
+  default = "10.1.0.0/16"
+}
+
+
+variable "instance_tanancy" {
+  default = "default"
+}
+

--- a/lab/ap-south-1/dev/vpc.tf
+++ b/lab/ap-south-1/dev/vpc.tf
@@ -1,0 +1,13 @@
+resource "aws_vpc" "main" {
+  cidr_block       = "${var.vpc_cidr}"
+  instance_tenancy = "${var.instance_tanancy}"
+
+
+   tags = {
+    Name        = "${var.environment}"
+    environment = "${var.environment}"
+    project     = "infrastructure"
+    team        = "RS"
+    application = "vpc"
+  }
+}

--- a/lab/main.tf
+++ b/lab/main.tf
@@ -3,3 +3,10 @@ module iam_groups {
    source = "./global/iam"
 
 }
+
+module vpc {
+
+   source = "./ap-south-1/dev"
+
+}
+


### PR DESCRIPTION
Terraform will perform the following actions:
```
  + module.vpc.aws_vpc.main
      id:                               <computed>
      arn:                              <computed>
      assign_generated_ipv6_cidr_block: "false"
      cidr_block:                       "10.1.0.0/16"
      default_network_acl_id:           <computed>
      default_route_table_id:           <computed>
      default_security_group_id:        <computed>
      dhcp_options_id:                  <computed>
      enable_classiclink:               <computed>
      enable_classiclink_dns_support:   <computed>
      enable_dns_hostnames:             <computed>
      enable_dns_support:               "true"
      instance_tenancy:                 "default"
      ipv6_association_id:              <computed>
      ipv6_cidr_block:                  <computed>
      main_route_table_id:              <computed>
      owner_id:                         <computed>
      tags.%:                           "5"
      tags.Name:                        "dev"
      tags.application:                 "vpc"
      tags.environment:                 "dev"
      tags.project:                     "infrastructure"
      tags.team:                        "RS"


Plan: 1 to add, 0 to change, 0 to destroy.
