### PR TITLE
created Subnet for public and private, Internet gateway  and routetable

### DIFF
--- a/lab/ap-south-1/dev/variables.tf
+++ b/lab/ap-south-1/dev/variables.tf
@@ -13,3 +13,12 @@ variable "instance_tanancy" {
   default = "default"
 }
 
+variable "public_subnet_cidr" {
+ description = "CIDR for the public subnet"
+ default = "10.1.1.0/24"
+}
+
+variable "private_subnet_cidr" {
+ description = "CIDR for the private subnet"
+ default = "10.1.2.0/24"
+}

--- a/lab/ap-south-1/dev/vpc.tf
+++ b/lab/ap-south-1/dev/vpc.tf
@@ -11,3 +11,54 @@ resource "aws_vpc" "main" {
     application = "vpc"
   }
 }
+
+#public subnet
+resource "aws_subnet" "public subnet" {
+vpc_id = "$(vpc.default.id}"
+cidr_block = "${var.public_subnet_cidr}"
+availability_zone = "${var.environment}"
+
+tags {
+  Name = "public subnet"
+ }
+}
+
+
+#private subnet
+resource "aws_subnet" "private subnet" {
+vpc_id = "$(vpc.default.id}"
+cidr_block = "${var.private_subnet_cidr}"
+availability_zone = "${var.environment}"
+
+tags {
+  Name = "private subnet"
+ }
+}
+
+#Internet Accessgateway
+resource "internet_gateway" "gw" {
+  vpc_id = "${vpc.default.id}"
+
+  tags {
+    Name = "VPC IGW"
+  }
+}
+
+#Routetable
+resource "aws_route_table" "web-public-rt" {
+  vpc_id = "${vpc.default.id}"
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${internet_gateway.gw.id}"
+  }
+
+  tags 
+    Name = "Public Subnet RT"
+  }
+
+# Assign the route table to the public Subnet
+resource "route_table_association" "web-public-rt" {
+  subnet_id = "${subnet.public-subnet.id}"
+  route_table_id = "${route_table.web-public-rt.id}"
+}

--- a/lab/ap-south-1/dev/vpc.tf
+++ b/lab/ap-south-1/dev/vpc.tf
@@ -14,7 +14,7 @@ resource "aws_vpc" "main" {
 
 #public subnet
 resource "aws_subnet" "public subnet" {
-vpc_id = "$(vpc.default.id}"
+vpc_id = "$(var.vpc_cidr}"
 cidr_block = "${var.public_subnet_cidr}"
 availability_zone = "${var.environment}"
 
@@ -26,7 +26,7 @@ tags {
 
 #private subnet
 resource "aws_subnet" "private subnet" {
-vpc_id = "$(vpc.default.id}"
+vpc_id = "$(var.vpc_cidr}"
 cidr_block = "${var.private_subnet_cidr}"
 availability_zone = "${var.environment}"
 
@@ -37,7 +37,7 @@ tags {
 
 #Internet Accessgateway
 resource "internet_gateway" "gw" {
-  vpc_id = "${vpc.default.id}"
+  vpc_id = "${var.vpc_cidr}"
 
   tags {
     Name = "VPC IGW"
@@ -46,7 +46,7 @@ resource "internet_gateway" "gw" {
 
 #Routetable
 resource "aws_route_table" "web-public-rt" {
-  vpc_id = "${vpc.default.id}"
+  vpc_id = "${var.vpc_cidr}"
 
   route {
     cidr_block = "0.0.0.0/0"


### PR DESCRIPTION
Created public and private subnet  & internet access gateway.

Below is the execution plan:
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  + module.vpc.aws_vpc.main
      id:                               <computed>
      arn:                              <computed>
      assign_generated_ipv6_cidr_block: "false"
      cidr_block:                       "10.1.0.0/16"
      default_network_acl_id:           <computed>
      default_route_table_id:           <computed>
      default_security_group_id:        <computed>
      dhcp_options_id:                  <computed>
      enable_classiclink:               <computed>
      enable_classiclink_dns_support:   <computed>
      enable_dns_hostnames:             <computed>
      enable_dns_support:               "true"
      instance_tenancy:                 "default"
      ipv6_association_id:              <computed>
      ipv6_cidr_block:                  <computed>
      main_route_table_id:              <computed>
      owner_id:                         <computed>
      tags.%:                           "5"
      tags.Name:                        "dev"
      tags.application:                 "vpc"
      tags.environment:                 "dev"
      tags.project:                     "infrastructure"
      tags.team:                        "RS"


Plan: 1 to add, 0 to change, 0 to destroy.
